### PR TITLE
React.jsx: type is invalid

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -132,6 +132,12 @@ declare module 'react-data-export' {
   export namespace ReactExport {
     export class ExcelFile extends React.Component<ExcelFileProps, any> {
     }
+    export namespace ExcelFile {
+      export class ExcelColumn extends React.Component<ExcelColumnProps, any> {
+      }
+      export class ExcelSheet extends React.Component<ExcelSheetProps, any> {
+      }
+    }
   }
   export default ReactExport
 }


### PR DESCRIPTION
[fix] type is invalid

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/securedeveloper/react-data-export/blob/master/CONTRIBUTING.md

  * If your PR fix an issue don't forget to update the unit test or add a new one
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Update examples whether is required
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature

-->
**Type: Typescript**

**Description:**

<!-- Resolves #??? -->
`Warning: React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.`


![Screenshot_20201211_191157](https://user-images.githubusercontent.com/31056871/101896974-c9d9ab80-3be4-11eb-8a5e-cca7dc7d0c0d.png)
